### PR TITLE
Add Homebrew to workflow PATH and check PHP version

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -203,7 +203,8 @@
 				<key>runningsubtext</key>
 				<string>Getting Spotifious data...</string>
 				<key>script</key>
-				<string>php -d display_errors='stderr' -f main.php -- "{query}"
+				<string>source set-php-path.sh
+php -d display_errors='stderr' -f main.php -- "{query}"
 
 # In case you are experiencing unsolveable issues,
 # you can generate a log file to help me. Modify the
@@ -289,7 +290,8 @@
 				<key>escaping</key>
 				<integer>4</integer>
 				<key>script</key>
-				<string>php -f action.php -- "{query}"
+				<string>source set-php-path.sh
+php -f action.php -- "{query}"
 
 # In case you are experiencing unsolveable issues,
 # you can generate a log file to help me. Modify the

--- a/set-php-path.sh
+++ b/set-php-path.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Add Homebrew to the path as a convenience for the user
+export PATH="/usr/local/bin:${PATH}"
+
+php_version_line="$(php --version | head -n 1)"
+# Shell-agnostic string contains
+if [ "${php_version_line#*PHP 5.3}" != "${php_version_line}" ]; then
+    echo "Error: PHP version must be >= 5.4" >&2
+    exit 1
+fi


### PR DESCRIPTION
Heya,

I ran into an issue where the server on localhost:11114 was silently refusing to start for the initial setup, and I tracked it down to the "-S" flag for the php CLI being added in 5.4 (OS X 10.8.5 by default apparently uses 5.3). To fix it, this PR adds 1) a PHP version check that will echo to STDERR for the Alfred debugger and 2) /usr/local/bin to the front of the wrapper script PATHs, so the user can use Homebrew to upgrade their PHP if need be.

Cheers,
mieubrisse