### PR TITLE
Fixes issue #93 for Spotifious::update_playlists_cache() API call

### DIFF
--- a/src/citelao/Spotifious/Spotifious.php
+++ b/src/citelao/Spotifious/Spotifious.php
@@ -88,7 +88,7 @@ class Spotifious {
 
 		// Fetch playlists on a first run...
 		if($api && $this->alfred->options('playlists') == '') {
-			$this->update_playlists_cache();
+			$this->update_playlists_cache($api);
 		}
 
 		if (mb_strlen($query) <= 3) {


### PR DESCRIPTION
- Spotifious::update_playlists_cache() is called without $api on initial
  run