### PR TITLE
Fix playlists in regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog #
 
-## v0.13.8 (pending) ##
+## v0.13.8 ##
 - Fixed: Support new Spotify playlist syntax (without `user:` prefix).
 
 ## v0.13.7 ##

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog #
 
+## v0.13.8 (pending) ##
+- Fixed: Support new Spotify playlist syntax (without `user:` prefix).
+
 ## v0.13.7 ##
 - Fixed: Bump up the Spotify API version so Spotifious works again
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Spotifious uses Packal to make sure you always have the latest version. It gives
 
 ## Download & Install ##
 
-Latest version: [v0.13.7](https://github.com/citelao/Spotify-for-Alfred/archive/master.zip) | Latest dev build: [v0.13.8](https://github.com/citelao/Spotify-for-Alfred/archive/dev.zip)
+Latest version: [v0.13.8](https://github.com/citelao/Spotify-for-Alfred/archive/master.zip) | Latest dev build: [v0.13.8](https://github.com/citelao/Spotify-for-Alfred/archive/dev.zip)
 
 An in-depth [installation guide](http://ben.stolovitz.com/Spotify-for-Alfred/download/) is available on the Spotifious website.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Spotifious uses Packal to make sure you always have the latest version. It gives
 
 ## Download & Install ##
 
-Latest version: [v0.13.7](https://github.com/citelao/Spotify-for-Alfred/archive/master.zip) | Latest dev build: [v0.13.7](https://github.com/citelao/Spotify-for-Alfred/archive/dev.zip)
+Latest version: [v0.13.7](https://github.com/citelao/Spotify-for-Alfred/archive/master.zip) | Latest dev build: [v0.13.8](https://github.com/citelao/Spotify-for-Alfred/archive/dev.zip)
 
 An in-depth [installation guide](http://ben.stolovitz.com/Spotify-for-Alfred/download/) is available on the Spotifious website.
 

--- a/info.plist
+++ b/info.plist
@@ -1086,7 +1086,7 @@ Spotifious works out of the box (just type `spotifious` in Alfred), but works be
 		</dict>
 	</dict>
 	<key>version</key>
-	<string>0.13.7</string>
+	<string>0.13.8</string>
 	<key>webaddress</key>
 	<string>https://github.com/citelao/Spotify-for-Alfred</string>
 </dict>

--- a/src/citelao/Spotifious/Spotifious.php
+++ b/src/citelao/Spotifious/Spotifious.php
@@ -334,7 +334,7 @@ class Spotifious {
 
 	// TODO cite
 	protected function is_spotify_uri($item) {
-		$regex = '/^(spotify:(?:album|artist|track|user:[^:]+:playlist):[a-zA-Z0-9]+)$/x';
+		$regex = '/^(spotify:(?:album|artist|track|(?:user:[^:]+:)?playlist):[a-zA-Z0-9]+)$/x';
 
 		return preg_match($regex, $item);
 	}


### PR DESCRIPTION
Spotify changed the URI format new playlists use, which broke the details page.

This change updates the URI parser to accept users optionally. 