### PR TITLE
Fixed PHP Deprecation Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog #
 
+## v0.13.9 ##
+- Fixed: Deprecation error thrown in newer versions of PHP for unparenthesized
+	left-associative ternary operator in `Spotifious.php`
+- Changed: Updated `spotifious.sublime-project` configuration to use relative
+	path of the workflow directory
+
 ## v0.13.8 ##
 - Fixed: Support new Spotify playlist syntax (without `user:` prefix).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Spotifious uses Packal to make sure you always have the latest version. It gives
 
 ## Download & Install ##
 
-Latest version: [v0.13.8](https://github.com/citelao/Spotify-for-Alfred/archive/master.zip) | Latest dev build: [v0.13.8](https://github.com/citelao/Spotify-for-Alfred/archive/dev.zip)
+Latest version: [v0.13.9](https://github.com/citelao/Spotify-for-Alfred/archive/master.zip) | Latest dev build: [v0.13.9](https://github.com/citelao/Spotify-for-Alfred/archive/dev.zip)
 
 An in-depth [installation guide](http://ben.stolovitz.com/Spotify-for-Alfred/download/) is available on the Spotifious website.
 

--- a/info.plist
+++ b/info.plist
@@ -1086,7 +1086,7 @@ Spotifious works out of the box (just type `spotifious` in Alfred), but works be
 		</dict>
 	</dict>
 	<key>version</key>
-	<string>0.13.8</string>
+	<string>0.13.9</string>
 	<key>webaddress</key>
 	<string>https://github.com/citelao/Spotify-for-Alfred</string>
 </dict>

--- a/spotifious.sublime-project
+++ b/spotifious.sublime-project
@@ -2,7 +2,7 @@
 	"folders":
 	[
 		{
-			"path": "/Users/citelao/Dropbox/Alfred/Alfred.alfredpreferences/workflows/spotifious"
+			"path": "."
 		}
 	]
 }

--- a/src/citelao/Spotifious/Spotifious.php
+++ b/src/citelao/Spotifious/Spotifious.php
@@ -400,11 +400,11 @@ class Spotifious {
 				'id' => $playlist->id,
 				'name' => $playlist->name,
 				'uri' => $playlist->uri,
-				'owner' => (property_exists($playlist->owner, 'display_name'))
-					? $playlist->owner->display_name
-					: (property_exists($playlist->owner, 'id'))
-						? $playlist->owner->id
-						: 'unknown'
+				'owner' => (
+					property_exists($playlist->owner, 'display_name')
+						? $playlist->owner->display_name
+						: property_exists($playlist->owner, 'id')
+					) ? $playlist->owner->id : 'unknown'
 			);
 		}
 		$datetime = new \DateTime("now");


### PR DESCRIPTION
Fixed a PHP deprecation error (_see screenshot below_) for newer versions of PHP, which was being thrown due to an unparenthesized left-associative ternary operator in [`Spotifious.php`](https://github.com/citelao/Spotify-for-Alfred/blob/a09fb931d93407faf44625dbca7ea16ef47109c0/src/citelao/Spotifious/Spotifious.php#L403).

You can read more on the **"changes and deprecations of PHP 7.4"** in [this article outtake](https://stitcher.io/blog/new-in-php-74#left-associative-ternary-operator-deprecation-rfc).

  
  

<br/>

![image](https://user-images.githubusercontent.com/890252/70585233-9d362280-1b91-11ea-9cd3-b6efdeae722f.png)

