### PR TITLE
Fix a bug that made Spotifious use XML output on newer versions of Alfred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog #
 
 ## v0.13.10 (pending) ##
-- Added: a test harness so we can automatically test Spotifious
+- Added: A test harness so we can automatically test Spotifious
+- Fixed: Ensure we use the always use the JSON format, which is escaped properly, in new versions
 
 ## v0.13.9 ##
 - Fixed: Deprecation error thrown in newer versions of PHP for unparenthesized

--- a/info.plist
+++ b/info.plist
@@ -1086,7 +1086,7 @@ Spotifious works out of the box (just type `spotifious` in Alfred), but works be
 		</dict>
 	</dict>
 	<key>version</key>
-	<string>0.13.9</string>
+	<string>0.13.10</string>
 	<key>webaddress</key>
 	<string>https://github.com/citelao/Spotify-for-Alfred</string>
 </dict>

--- a/src/citelao/OhAlfred/OhAlfred.php
+++ b/src/citelao/OhAlfred/OhAlfred.php
@@ -46,10 +46,21 @@ class OhAlfred {
 		return $this->version;
 	}
 
+	// Helper for versions
+	public function majorVersion()
+	{
+		return intval($this->version()[0]);
+	}
+
 	// Helper for Alfred 3
 	public function isAlfred3()
 	{
-		return $this->version()[0] === "3";
+		return $this->majorVersion() === 3;
+	}
+
+	public function isAlfred3OrGreater()
+	{
+		return $this->majorVersion() >= 3;
 	}
 
 	// Get the user's home directory.
@@ -168,7 +179,7 @@ class OhAlfred {
 			$r = $this->results;
 
 		$output = "";
-		if($this->isAlfred3()) {
+		if($this->isAlfred3OrGreater()) {
 			$output = $this->jsonify($r);
 		} else {
 			$output = $this->xmlify($r);

--- a/src/citelao/OhAlfred/OhAlfred.php
+++ b/src/citelao/OhAlfred/OhAlfred.php
@@ -52,14 +52,9 @@ class OhAlfred {
 		return intval($this->version()[0]);
 	}
 
-	// Helper for Alfred 3
-	public function isAlfred3()
+	public function doesAlfredSupportJson()
 	{
-		return $this->majorVersion() === 3;
-	}
-
-	public function isAlfred3OrGreater()
-	{
+		// Alfred 3 introduced the JSON format for results.
 		return $this->majorVersion() >= 3;
 	}
 
@@ -179,7 +174,7 @@ class OhAlfred {
 			$r = $this->results;
 
 		$output = "";
-		if($this->isAlfred3OrGreater()) {
+		if($this->doesAlfredSupportJson()) {
 			$output = $this->jsonify($r);
 		} else {
 			$output = $this->xmlify($r);


### PR DESCRIPTION
Today, Spotifious has the ability to use JSON output (which is correctly escaped, especially for `<` and `>`), but it only chooses to use it in Alfred 3. This changes Spotifious so it uses JSON style for all versions of Alfred `>= 3`.

## What happened?

We had a hard-coded check for version `=== 3`, but it should have been `>= 3`.

* Introduced a type-converting helper method for getting the major version number.
* Updated the `isAlfred3` check to be more descriptive: `doesAlfredSupportJson`
* Updated the condition to be `>= 3`.

## How tested?

* [x] Output works!
* [x] Output is JSON!